### PR TITLE
Fix the hardware crash caused by null pointer.

### DIFF
--- a/samples/sample_c/platform/rtos_freertos/common/osal/osal.c
+++ b/samples/sample_c/platform/rtos_freertos/common/osal/osal.c
@@ -205,6 +205,7 @@ void *Osal_Malloc(uint32_t size)
 
 void Osal_Free(void *ptr)
 {
+    if(!ptr) return;
     vPortFree(ptr);
 }
 


### PR DESCRIPTION
Fix the hardware crash caused by null pointer. In the process of [DjiWidget_RegHandlerList]