### PR TITLE
fix: fix docstrings for T_DjiPositioningPosition

### DIFF
--- a/psdk_lib/include/dji_positioning.h
+++ b/psdk_lib/include/dji_positioning.h
@@ -61,7 +61,7 @@ typedef struct {
 typedef struct {
     dji_f64_t longitude; /*!< Specifies longitude, unit: degree. */
     dji_f64_t latitude; /*!< Specifies latitude, unit: degree. */
-    dji_f64_t height; /*!< Specifies height above sea level, unit: m. */
+    dji_f64_t height; /*!< Specifies height above sea level or above ground level, unit: m. */
 } T_DjiPositioningPosition;
 
 /**


### PR DESCRIPTION
For example, T_DjiPositioningPositionInfo use T_DjiPositioningPosition in GROUND (AGL) coordinate system instead of ASL like documented here.