### PR TITLE
make Payload-SDK get compiled in ubuntu 22.04

### DIFF
--- a/samples/sample_c++/module_sample/flight_controller/test_flight_controller_command_flying.cpp
+++ b/samples/sample_c++/module_sample/flight_controller/test_flight_controller_command_flying.cpp
@@ -38,6 +38,10 @@
 #include "opencv2/opencv.hpp"
 #include "opencv2/highgui/highgui.hpp"
 
+#if CV_MAJOR_VERSION >= 4
+#include "opencv2/imgproc/types_c.h"
+#endif
+
 using namespace cv;
 #endif
 

--- a/samples/sample_c++/platform/linux/manifold2/CMakeLists.txt
+++ b/samples/sample_c++/platform/linux/manifold2/CMakeLists.txt
@@ -118,7 +118,7 @@ if (OPUS_FOUND)
     message(STATUS " - Libraries: ${OPUS_LIBRARY}")
 
     add_definitions(-DOPUS_INSTALLED)
-    target_link_libraries(${PROJECT_NAME} /usr/local/lib/libopus.a)
+    target_link_libraries(${PROJECT_NAME} opus)
 else ()
     message(STATUS "Cannot Find OPUS")
 endif (OPUS_FOUND)

--- a/samples/sample_c/platform/linux/manifold2/CMakeLists.txt
+++ b/samples/sample_c/platform/linux/manifold2/CMakeLists.txt
@@ -65,7 +65,7 @@ if (OPUS_FOUND)
     message(STATUS " - Libraries: ${OPUS_LIBRARY}")
 
     add_definitions(-DOPUS_INSTALLED)
-    target_link_libraries(${PROJECT_NAME} /usr/local/lib/libopus.a)
+    target_link_libraries(${PROJECT_NAME} opus)
 else ()
     message(STATUS "Cannot Find OPUS")
 endif (OPUS_FOUND)


### PR DESCRIPTION
currently, Payload-SDK cannot be compiled using ubuntu 22.04. This patch makes it pass the compilation.

note that opencv4 is the default version in the official repo of ubuntu 22.04