### PR TITLE
fix:modify CMakeLists to fix Link Error while building on raspberry-pi5

### DIFF
--- a/samples/sample_c++/platform/linux/raspberry_pi/CMakeLists.txt
+++ b/samples/sample_c++/platform/linux/raspberry_pi/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(dji_sdk_demo_on_rpi_cxx CXX)
+project(dji_sdk_demo_on_rpi_cxx)
 
 set(CMAKE_C_FLAGS "-pthread -std=gnu99")
 set(CMAKE_CXX_FLAGS "-std=c++11 -pthread")
@@ -7,6 +7,10 @@ set(CMAKE_EXE_LINKER_FLAGS "-pthread")
 set(CMAKE_C_COMPILER "aarch64-linux-gnu-gcc")
 set(CMAKE_CXX_COMPILER "aarch64-linux-gnu-g++")
 add_definitions(-D_GNU_SOURCE)
+
+if (NOT USE_SYSTEM_ARCH)
+    add_definitions(-DSYSTEM_ARCH_LINUX)
+endif ()
 
 if (MEMORY_LEAK_CHECK_ON MATCHES TRUE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")

--- a/samples/sample_c/module_sample/utils/util_file.h
+++ b/samples/sample_c/module_sample/utils/util_file.h
@@ -27,11 +27,11 @@
 #ifndef UTIL_FILE_H
 #define UTIL_FILE_H
 
+#ifdef SYSTEM_ARCH_LINUX
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#ifdef SYSTEM_ARCH_LINUX
 
 /* Includes ------------------------------------------------------------------*/
 #include <dji_typedef.h>

--- a/samples/sample_c/module_sample/utils/util_time.h
+++ b/samples/sample_c/module_sample/utils/util_time.h
@@ -27,11 +27,12 @@
 #ifndef DJI_UTIL_TIME_H
 #define DJI_UTIL_TIME_H
 
+#ifdef SYSTEM_ARCH_LINUX
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifdef SYSTEM_ARCH_LINUX
 
 /* Includes ------------------------------------------------------------------*/
 #include <stdint.h>


### PR DESCRIPTION
解决编译源码包中 raspberry-pi 的 c++ 版本示例代码，报链接错误的问题（源码目录：Payload-SDK\samples\sample_c++\platform\linux\raspberry_pi）
报错输出日志如下（截取部分）：
......
/usr/bin/ld: application.cpp:(.text+0xec): undefined reference to `HalNetWork_GetDeviceInfo'
/usr/bin/ld: application.cpp:(.text+0xf0): undefined reference to `HalNetWork_GetDeviceInfo'
/usr/bin/ld: application.cpp:(.text+0xf8): undefined reference to `Osal_Socket'
......