### PR TITLE
Add automatic Raspberry Pi detection for platform selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 
+# Set CMake policy CMP0053 to use new variable reference evaluation rules
+# This is the standard way to handle CMP0053 warnings in modern CMake projects
+if(POLICY CMP0053)
+    cmake_policy(SET CMP0053 NEW)
+endif()
+
 if (NOT USE_SYSTEM_ARCH)
     # select use platform 'LINUX' or 'RTOS' here, reset cache and reload cmake project
     set(USE_SYSTEM_ARCH LINUX)
@@ -27,14 +33,38 @@ endif ()
 
 if (USE_SYSTEM_ARCH MATCHES LINUX)
     add_definitions(-DSYSTEM_ARCH_LINUX)
-    add_subdirectory(samples/sample_c/platform/linux/manifold2)
-    add_subdirectory(samples/sample_c++/platform/linux/manifold2)
+    
+    # Detect Raspberry Pi
+    # /proc/device-tree/model is the standard way to detect Raspberry Pi on ARM systems
+    # It exists on all modern Raspberry Pi models and provides accurate model information
+    set(IS_RASPBERRY_PI FALSE)
+    if (EXISTS "/proc/device-tree/model")
+        file(READ "/proc/device-tree/model" RPI_MODEL)
+        string(STRIP "${RPI_MODEL}" RPI_MODEL)
+        if (RPI_MODEL MATCHES "Raspberry Pi")
+            set(IS_RASPBERRY_PI TRUE)
+            message(STATUS "Detected Raspberry Pi: ${RPI_MODEL}")
+        endif ()
+    endif ()
     
     execute_process(COMMAND uname -m OUTPUT_VARIABLE DEVICE_SYSTEM_ID)
     if (DEVICE_SYSTEM_ID MATCHES x86_64)
         set(LIBRARY_PATH psdk_lib/lib/x86_64-linux-gnu-gcc)
+        # x86_64 is always manifold2
+        add_subdirectory(samples/sample_c/platform/linux/manifold2)
+        add_subdirectory(samples/sample_c++/platform/linux/manifold2)
     elseif (DEVICE_SYSTEM_ID MATCHES aarch64)
         set(LIBRARY_PATH psdk_lib/lib/aarch64-linux-gnu-gcc)
+        # For aarch64, check if it's Raspberry Pi
+        if (IS_RASPBERRY_PI)
+            message(STATUS "Building for Raspberry Pi platform")
+            add_subdirectory(samples/sample_c/platform/linux/raspberry_pi)
+            add_subdirectory(samples/sample_c++/platform/linux/raspberry_pi)
+        else ()
+            message(STATUS "Building for Manifold2 platform")
+            add_subdirectory(samples/sample_c/platform/linux/manifold2)
+            add_subdirectory(samples/sample_c++/platform/linux/manifold2)
+        endif ()
     else ()
         message(FATAL_ERROR "FATAL: Please confirm your platform.")
     endif ()


### PR DESCRIPTION
## Summary

This PR adds automatic Raspberry Pi hardware detection to the CMake build system, enabling automatic platform selection between `raspberry_pi` and `manifold2` based on the detected hardware.

## Changes

### 1. Automatic Raspberry Pi Detection

- Added detection logic that checks `/proc/device-tree/model` to identify Raspberry Pi hardware
  - Example output from `/proc/device-tree/model`
     ```
     $ cat /proc/device-tree/model
     Raspberry Pi 5 Model B Rev 1.1
     ```
- When Raspberry Pi is detected on an `aarch64` system, the build system automatically selects the `raspberry_pi` platform
- Falls back to `manifold2` platform for other `aarch64` systems (e.g., Manifold2-G/C)

### 2. CMake Policy Configuration

- Set CMake policy `CMP0053` to `NEW` to resolve variable reference evaluation warnings

## Motivation

Previously, the root `CMakeLists.txt` only supported `manifold2` and `RTOS` platforms, requiring manual configuration to build for Raspberry Pi. This change enables automatic platform detection, making it easier to build the Payload SDK on Raspberry Pi without manual intervention.

## Testing

- ✅ Tested on Raspberry Pi 5 Model B (aarch64)
  - OS: Ubuntu 24.04.3 Raspberry Pi Generic (64-bit ARM) server
  - Correctly detects Raspberry Pi hardware
  - Automatically selects `raspberry_pi` platform
  - Build completes successfully

**Evidence**: Build logs from both `cmake` and `make` commands are attached as [cmake_logs.zip](https://github.com/user-attachments/files/24351428/cmake_logs.zip) .

## Impact

- **Breaking Changes**: None
- **Backward Compatibility**: Fully maintained